### PR TITLE
Optimize query by selecting once per source

### DIFF
--- a/sqls/monthly_arr.sql
+++ b/sqls/monthly_arr.sql
@@ -1,9 +1,12 @@
-with customer_summary as (
+with revenue as (
+  select * from {revenue} rev
+
+), customer_summary as (
   select
     stripe_customer_id
     , min(date_trunc('month', recognized_at))::date as min_month_per_customer
     , max(date_trunc('month', recognized_at))::date as max_month_per_customer
-  from {revenue} rev
+  from revenue
   group by 1
 
 ), months_per_customer as (
@@ -16,12 +19,12 @@ with customer_summary as (
   select
     months_per_customer.month
     , months_per_customer.stripe_customer_id
-    , rev.customer_name
-    , sum(rev.amount) as total_per_customer
-   from {revenue} rev
+    , revenue.customer_name
+    , sum(revenue.amount) as total_per_customer
+   from revenue
    full outer join months_per_customer
-     on months_per_customer.month::date = rev.month
-       and months_per_customer.stripe_customer_id = rev.stripe_customer_id
+     on months_per_customer.month::date = revenue.month
+       and months_per_customer.stripe_customer_id = revenue.stripe_customer_id
   group by 1,2,3
 
  ), summary_including_previous_values as (

--- a/sqls/monthly_customers.sql
+++ b/sqls/monthly_customers.sql
@@ -1,9 +1,12 @@
-with customer_summary as (
+with revenue as (
+  select * from {revenue} rev
+
+), customer_summary as (
   select
     stripe_customer_id
     , min(date_trunc('month', recognized_at))::date as min_month_per_customer
     , max(date_trunc('month', recognized_at))::date as max_month_per_customer
-  from {revenue} rev
+  from revenue
   group by 1
 
 ), months_per_customer as (
@@ -16,11 +19,11 @@ with customer_summary as (
   select
     months_per_customer.month
     , months_per_customer.stripe_customer_id
-    , sum(rev.amount) as total_per_customer
-   from {revenue} rev
+    , sum(revenue.amount) as total_per_customer
+   from revenue
    full outer join months_per_customer
-     on months_per_customer.month::date = rev.month
-       and months_per_customer.stripe_customer_id = rev.stripe_customer_id
+     on months_per_customer.month::date = revenue.month
+       and months_per_customer.stripe_customer_id = revenue.stripe_customer_id
   group by 1,2
 
  ), summary_including_previous_values as (

--- a/sqls/public/exported_metrics.sql
+++ b/sqls/public/exported_metrics.sql
@@ -1,161 +1,167 @@
-with arrs as (
+with quarterly_arr as (
+  select * from {quarterly_arr} arr
+
+), quarterly_customers as (
+  select * from {quarterly_customers} customers
+
+), arrs as (
   select
-    quarter_name
-    , quarter
+    quarter
+    , quarter_name
     , 'Beginning ARR' as metric
     , beginning_arr as value
-  from {quarterly_arr} arr
+  from quarterly_arr arr
 
   union all
 
   select
-    quarter_name
-    , quarter
+    quarter
+    , quarter_name
     , 'New ARR' as metric
     , new_arr as value
-  from {quarterly_arr} arr
+  from quarterly_arr arr
 
   union all
 
   select
-    quarter_name
-    , quarter
+    quarter
+    , quarter_name
     , 'Expansion ARR' as metric
     , expansion_arr as value
-  from {quarterly_arr} arr
+  from quarterly_arr arr
 
   union all
 
   select
-    quarter_name
-    , quarter
+    quarter
+    , quarter_name
     , 'Contraction ARR' as metric
     , contraction_arr as value
-  from {quarterly_arr} arr
+  from quarterly_arr arr
 
   union all
 
   select
-    quarter_name
-    , quarter
+    quarter
+    , quarter_name
     , 'Churn ARR' as metric
     , churn_arr as value
-  from {quarterly_arr} arr
+  from quarterly_arr arr
 
   union all
 
   select
-    quarter_name
-    , quarter
+    quarter
+    , quarter_name
     , 'Ending ARR' as metric
     , ending_arr as value
-  from {quarterly_arr} arr
+  from quarterly_arr arr
 
   union all
 
   select
-    quarter_name
-    , quarter
+    quarter
+    , quarter_name
     , 'ARR % YoY growth' as metric
     , yearly_growth_rate as value
-  from {quarterly_arr} arr
+  from quarterly_arr arr
   where yearly_growth_rate is not null
 
   union all
 
   select
     quarter
-    , quarter_at
+    , quarter_name
     , 'ARR % Quarterly growth' as metric
     , quarterly_growth_rate as value
-  from {quarterly_arr} arr
+  from quarterly_arr arr
   where quarterly_growth_rate is not null
 
   union all
 
   select
     quarter
-    , quarter_at
+    , quarter_name
     , 'ARR Quarterly Expansion Rate' as metric
     , expansion_rate as value
-  from {quarterly_arr} arr
+  from quarterly_arr arr
   where expansion_rate is not null
 
 ), customers as (
   select
-    quarter_name
-    , quarter
+    quarter
+    , quarter_name
     , 'Beginning customers' as metric
     , beginning_customers as value
-  from {quarterly_customers} customers
+  from quarterly_customers customers
 
   union all
 
   select
-    quarter_name
-    , quarter
+    quarter
+    , quarter_name
     , 'New customers' as metric
     , new_customers as value
-  from {quarterly_customers} customers
+  from quarterly_customers customers
 
   union all
 
   select
-    quarter_name
-    , quarter
+    quarter
+    , quarter_name
     , 'Churn customers' as metric
     , churn_customers as value
-  from {quarterly_customers} customers
+  from quarterly_customers customers
 
   union all
 
   select
-    quarter_name
-    , quarter
+    quarter
+    , quarter_name
     , 'Ending customers' as metric
     , ending_customers as value
-  from {quarterly_customers} customers
+  from quarterly_customers customers
 
   union all
 
   select
-    quarter_name
-    , quarter
+    quarter
+    , quarter_name
     , 'Customers % YoY growth' as metric
     , yearly_growth_rate as value
-  from {quarterly_customers} customers
+  from quarterly_customers customers
   where yearly_growth_rate is not null
 
   union all
 
   select
     quarter
-    , quarter_at
+    , quarter_name
     , 'Customers % Quarterly growth' as metric
     , quarterly_growth_rate as value
-  from {quarterly_customers} customers
+  from quarterly_customers customers
   where quarterly_growth_rate is not null
 
   union all
 
   select
     quarter
-    , quarter_at
+    , quarter_name
     , 'Customer Quarterly Churn Rate' as metric
     , churn_rate as value
-  from {quarterly_customers} customers
+  from quarterly_customers customers
   where churn_rate is not null
 
 ), acv as (
 
 select
     quarter
-    , quarter_at
+    , quarter_name
     , 'Annual Contract Value'
     , 1.0 * ending_arr / ending_customers as acv
-from {quarterly_customers} customers
-left join {quarterly_arr} arr
-    using (quarter, quarter_at)
+from quarterly_customers customers
+left join quarterly_arr arr
+    using (quarter, quarter_name)
 
 ), final as (
   select * from arrs

--- a/sqls/quarterly_arr.sql
+++ b/sqls/quarterly_arr.sql
@@ -52,8 +52,8 @@ with monthly_arr as (
     , contraction_arr
     , churn_arr
     , ending_arr
-    , lag(ending_arr, 4) over (order by quarter_at) as last_year_arr
-    , lag(ending_arr) over (order by quarter_at) as last_quarter_arr
+    , lag(ending_arr, 4) over (order by quarter) as last_year_arr
+    , lag(ending_arr) over (order by quarter) as last_quarter_arr
 
   from changing_arrs
   full outer join beginning_ending_arrs

--- a/sqls/quarterly_customers.sql
+++ b/sqls/quarterly_customers.sql
@@ -48,8 +48,8 @@ with monthly_customers as (
     , new_customers
     , churn_customers
     , ending_customers
-    , lag(ending_customers, 4) over (order by quarter_at) as last_year_customers
-    , lag(ending_customers) over (order by quarter_at) as last_quarter_customers
+    , lag(ending_customers, 4) over (order by quarter) as last_year_customers
+    , lag(ending_customers) over (order by quarter) as last_quarter_customers
 
   from monthly_changing_customers
   full outer join beginning_ending_customers

--- a/sqls/revenue.sql
+++ b/sqls/revenue.sql
@@ -1,4 +1,10 @@
-with monthly_invoices as (
+with invoice as (
+  select * from {stripe_invoice} invoice
+
+), subscription as (
+  select * from {stripe_subscription} subscription
+
+), monthly_invoices as (
    select
      invoice.total as amount
      , invoice.period_ended_at::date as date
@@ -9,8 +15,8 @@ with monthly_invoices as (
      , subscription.product_name as product_name
      , 'monthly' as billing_cycle
      , invoice.customer_id as stripe_customer_id
-   from {stripe_invoice} invoice
-   join {stripe_subscription} subscription
+   from invoice
+   join subscription
     on subscription.id = invoice.subscription_id
    where invoice.total > 0 -- removes refunds
    and subscription.plan_recurring_interval = 'month'
@@ -48,8 +54,8 @@ with monthly_invoices as (
          , subscription.product_name
          , 'annually' as billing_cycle
          , invoice.customer_id as stripe_customer_id
-   from {stripe_invoice} invoice
-   join {stripe_subscription} subscription
+   from invoice
+   join subscription
     on subscription.id = invoice.subscription_id
    where subscription.plan_recurring_interval = 'year'
      and subscription.plan_recurring_interval_count = 1

--- a/sqls/stripe_subscription.sql
+++ b/sqls/stripe_subscription.sql
@@ -1,8 +1,11 @@
-with plan_amount as (  -- plan = consolidation of all prices into one
+with item as (
+  select * from {stripe_subscription_item} item
+
+), plan_amount as (  -- plan = consolidation of all prices into one
   select
     subscription_id
     , sum(price_amount) as amount
-  from {stripe_subscription_item} item
+  from item
   group by 1
 
 ), plan as (
@@ -17,7 +20,7 @@ with plan_amount as (  -- plan = consolidation of all prices into one
     , price_id
     , product_id
     , row_number() over (partition by subscription_id order by created_at asc)  -- allow selecting oldest on conflict
-  from {stripe_subscription_item} item
+  from item
   left join plan_amount using (subscription_id)  -- add amount that includes other prices
   where is_main_product
 

--- a/sqls/stripe_subscription_item.sql
+++ b/sqls/stripe_subscription_item.sql
@@ -1,4 +1,7 @@
-with price_tier as (
+with price as (
+  select * from {stripe_price} price
+
+), price_tier as (
   select
     id as price_id
     , flat_amount::float / 100 as flat_amount
@@ -19,7 +22,7 @@ with price_tier as (
     , lag(up_to_quantity) over (partition by item.id order by order_index) as tier_last_up_to_quantity
     , order_index
   from {stripe_schema}.subscription_item item
-  left join {stripe_price} price
+  left join price
     on item.plan_id = price.id
   left join  price_tier
     on price.id = price_tier.price_id
@@ -63,7 +66,7 @@ with price_tier as (
     , plan_id as price_id
     , price.product_id
   from {stripe_schema}.subscription_item item
-  left join {stripe_price} price
+  left join price
     on item.plan_id = price.id
   left join item_amount
     on item.id = item_amount.item_id


### PR DESCRIPTION
Each select from upstream changes to a subquery, so multiple selects of the same is expensive.